### PR TITLE
fix -Werror=format-security

### DIFF
--- a/tclxslt-libxslt.c
+++ b/tclxslt-libxslt.c
@@ -1507,7 +1507,7 @@ TclXSLTExtFunction(xpathCtxt, nargs)
     valuePush(xpathCtxt, obj);
   } else {
     xmlGenericError(xmlGenericErrorContext,
-		    Tcl_GetStringFromObj(resultPtr, NULL));
+		    "%s", Tcl_GetStringFromObj(resultPtr, NULL));
     /* Need to define a new error code - this is the closest in meaning */
     xpathCtxt->error = XPATH_UNKNOWN_FUNC_ERROR;
   }


### PR DESCRIPTION
With some paranoid setting (`-Werror=format-security`), gcc complains about having non-constant formats in `printf` like functions. They will fails if the argument contains a `%`. This patch just sets a normal string format instead.