### PR TITLE
Revert pkgIndex.tcl to original version

### DIFF
--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -1,5 +1,165 @@
+# TclXML combo package index file - handcrafted
 #
-# Tcl package index file
-#
-package ifneeded @PACKAGE_NAME@ @PACKAGE_VERSION@ \
-    [list load [file join $dir @PKG_LIB_FILE@] @PACKAGE_NAME@]
+# $Id: pkgIndex.tcl.in,v 1.13 2003/12/03 20:06:34 balls Exp $
+
+namespace eval ::xml {
+    variable _init 0
+}
+namespace eval ::xml::libxml2 {
+    variable _init 0
+}
+namespace eval ::dom {
+    variable _init 0
+}
+namespace eval ::dom::libxml2 {
+    variable _init 0
+}
+namespace eval ::xslt {
+    variable _init 0
+}
+
+# From http://wiki.tcl.tk/9427
+proc ::xml::_platform {} {
+    global tcl_platform
+
+    set plat [lindex $tcl_platform(os) 0]
+    set mach $tcl_platform(machine)
+    switch -glob -- $mach {
+	sun4* {
+	    set mach sparc
+	}
+	intel -
+	i*86* {
+	    set mach x86
+	}
+	{Power Macintosh} {
+	    set mach ppc
+	}
+    }
+    return "$plat-$mach"
+}
+
+proc ::xml::_loadlib {dir package version} {
+    global tcl_platform
+
+    set lib $package[info sharedlibextension]
+    return [file join $dir [_platform] $lib]
+}
+
+namespace eval ::xml {
+    variable pkginit
+
+    if {![info exists pkginit]} {
+	set pkginit 0
+    }
+
+    # Try to locate the binary library:
+    # 1) Using TEA conventions
+    # 2) Using StarKit conventions
+    # 3) Using platform-specific conventions
+
+    proc pkgload {dir {binary 0} {cmd {}}} {
+	variable pkginit
+
+	if {$pkginit} {return {}}
+
+	namespace eval :: [format {
+	    package require xmldefs @PACKAGE_VERSION@
+	    package require xml::tcl @PACKAGE_VERSION@
+	    # TEA style
+	    if {[catch {load [file join [list %s] @PKG_LIB_FILE@] Tclxml}]} {
+		# StarKit style
+		if {[catch {load [::xml::_loadlib [list %s] Tclxml @PACKAGE_VERSION@]}]} {
+		    # Mac OS X frameworks are different
+	            if {[catch {load [file join [list %s] .. .. Tclxml] Tclxml}]} {
+		        # Unable to load binary implmentation,
+		        # just use pure-Tcl implmentation instead
+		        if {$binary} {
+			    return -code error "unable to load shared library"
+		        }
+	            } else {
+		        set ::xml::libxml2::_init 1
+		        set ::dom::libxml2::_init 1
+		        set ::xslt::_init 1
+		        source [file join [list %s] tcldom-libxml2.tcl]
+		        source [file join [list %s] tclxslt-libxslt.tcl]
+	            }
+	        } else {
+		    set ::xml::libxml2::_init 1
+		    set ::dom::libxml2::_init 1
+		    set ::xslt::_init 1
+		    source [file join [list %s] tcldom-libxml2.tcl]
+		    source [file join [list %s] tclxslt-libxslt.tcl]
+	        }
+	    } else {
+		set ::xml::libxml2::_init 1
+		set ::dom::libxml2::_init 1
+		set ::xslt::_init 1
+		source [file join [list %s] tcldom-libxml2.tcl]
+		source [file join [list %s] tclxslt-libxslt.tcl]
+	    }
+	    package require xml::tclparser @PACKAGE_VERSION@
+	    package provide tclparser @PACKAGE_VERSION@
+	    package provide xml::libxml2 @PACKAGE_VERSION@
+	    package provide xml @PACKAGE_VERSION@
+	    package provide dom @PACKAGE_VERSION@
+	    package provide dom::libxml2 @PACKAGE_VERSION@
+	    package provide xslt @PACKAGE_VERSION@
+	    package provide xslt::libxslt @PACKAGE_VERSION@
+
+	    set pkginit 1
+	} $dir $dir $dir $dir $dir $dir $dir $dir $dir $dir]
+
+	eval $cmd
+    }
+}
+
+package ifneeded xml::tcl     @PACKAGE_VERSION@ [list source [file join $dir xml__tcl.tcl]]
+package ifneeded sgmlparser   1.1       [list source [file join $dir sgmlparser.tcl]]
+package ifneeded xpath        1.0       [list source [file join $dir xpath.tcl]]
+package ifneeded xmldep       1.0       [list source [file join $dir xmldep.tcl]]
+
+# Requesting a specific package means we want it to be the default parser class.
+
+package ifneeded xml::libxml2 @PACKAGE_VERSION@ [list ::xml::pkgload $dir 1 {::xml::parser default libxml2}]
+
+# tclparser works with either xml::c or xml::tcl
+package ifneeded tclparser @PACKAGE_VERSION@ [list ::xml::pkgload $dir 0 {
+    ::xml::parser default tclparser
+    package provide tclparser @PACKAGE_VERSION@
+}]
+
+# use tcl only (mainly for testing)
+package ifneeded puretclparser @PACKAGE_VERSION@ "
+    package require xml::tcl       @PACKAGE_VERSION@
+    package require xmldefs
+    package require xml::tclparser @PACKAGE_VERSION@
+    package provide puretclparser  @PACKAGE_VERSION@
+"
+
+# Requesting the generic package leaves the choice of default parser automatic
+
+package ifneeded xml @PACKAGE_VERSION@ [list ::xml::pkgload $dir 0]
+package ifneeded dom @PACKAGE_VERSION@ [list ::xml::pkgload $dir 0]
+package ifneeded dom::libxml2 @PACKAGE_VERSION@ [list ::xml::pkgload $dir 1]
+package ifneeded xslt @PACKAGE_VERSION@ [list ::xml::pkgload $dir 1]
+package ifneeded xslt::libxslt @PACKAGE_VERSION@ [list ::xml::pkgload $dir 1]
+
+package ifneeded xmlswitch @PACKAGE_VERSION@ [list source [file join $dir xmlswitch.tcl]]
+
+package ifneeded xslt::cache @PACKAGE_VERSION@ [list source [file join $dir xsltcache.tcl]]
+package ifneeded xslt::utilities 1.2 [list source [file join $dir utilities.tcl]]
+package ifneeded xslt::process 1.1 [list source [file join $dir process.tcl]]
+package ifneeded xslt::resources 1.3 [list source [file join $dir resources.tcl]]
+
+if {[info tclversion] <= 8.0} {
+    package ifneeded sgml           1.9       [list source [file join $dir sgml-8.0.tcl]]
+    package ifneeded xmldefs        @PACKAGE_VERSION@ [list source [file join $dir xml-8.0.tcl]]
+    package ifneeded xml::tclparser @PACKAGE_VERSION@ [list source [file join $dir tclparser-8.0.tcl]]
+} else {
+    package ifneeded sgml           1.9       [list source [file join $dir sgml-8.1.tcl]]
+    package ifneeded xmldefs        @PACKAGE_VERSION@ [list source [file join $dir xml-8.1.tcl]]
+    package ifneeded xml::tclparser @PACKAGE_VERSION@ [list source [file join $dir tclparser-8.1.tcl]]
+}
+
+


### PR DESCRIPTION
The new version is too simple and does not work:

```
% package require xml
attempt to provide package xml 3.2 failed: no version of package xml provided
```
